### PR TITLE
change username-pwd delimiter in log from / to ]/[ allowing pwd with / c...

### DIFF
--- a/kippo/core/auth.py
+++ b/kippo/core/auth.py
@@ -158,10 +158,10 @@ class HoneypotPasswordChecker:
 
     def checkUserPass(self, username, password):
         if UserDB().checklogin(username, password):
-            log.msg( 'login attempt [%s/%s] succeeded' % (username, password) )
+            log.msg( 'login attempt [%s]/[%s] succeeded' % (username, password) )
             return True
         else:
-            log.msg( 'login attempt [%s/%s] failed' % (username, password) )
+            log.msg( 'login attempt [%s]/[%s] failed' % (username, password) )
             return False
 
 # vim: set sw=4 et:

--- a/kippo/core/dblog.py
+++ b/kippo/core/dblog.py
@@ -21,9 +21,9 @@ class DBLogger(object):
         self.re_map = [(re.compile(x[0]), x[1]) for x in (
             ('^connection lost$',
                 self._connectionLost),
-            ('^login attempt \[(?P<username>.*)/(?P<password>.*)\] failed',
+            ('^login attempt \[(?P<username>.*)\]/\[(?P<password>.*)\] failed',
                 self.handleLoginFailed),
-            ('^login attempt \[(?P<username>.*)/(?P<password>.*)\] succeeded',
+            ('^login attempt \[(?P<username>.*)\]/\[(?P<password>.*)\] succeeded',
                 self.handleLoginSucceeded),
             ('^Opening TTY log: (?P<logfile>.*)$',
                 self.handleTTYLogOpened),


### PR DESCRIPTION
Changed username-pwd delimiter in log from simple '/' to a more complex  ']/[' allowing pwd with '/' char inside. So dblog module will parse correctly username & password.

Regards