### PR TITLE
IP address added to credential checkers

### DIFF
--- a/kippo/core/auth.py
+++ b/kippo/core/auth.py
@@ -8,7 +8,8 @@ from zope.interface import implementer
 import twisted
 
 from twisted.cred.checkers import ICredentialsChecker
-from twisted.cred.credentials import IUsernamePassword, ISSHPrivateKey, IPluggableAuthenticationModules
+from twisted.cred.credentials import IUsernamePassword, ISSHPrivateKey, \
+    IPluggableAuthenticationModules, ICredentials
 from twisted.cred.error import UnauthorizedLogin, UnhandledCredentials
 
 from twisted.internet import defer
@@ -28,8 +29,7 @@ class UserDB(object):
     def load(self):
         '''load the user db'''
 
-        userdb_file = '%s/userdb.txt' % \
-            (config().get('honeypot', 'data_path'),)
+        userdb_file = '%s/userdb.txt' % (config().get('honeypot', 'data_path'))
 
         f = open(userdb_file, 'r')
         while True:
@@ -41,7 +41,7 @@ class UserDB(object):
             if not line:
                 continue
 
-            if line.startswith( '#' ):
+            if line.startswith('#'):
                 continue
 
             (login, uid_str, passwd) = line.split(':', 2)
@@ -59,8 +59,7 @@ class UserDB(object):
     def save(self):
         '''save the user db'''
 
-        userdb_file = '%s/userdb.txt' % \
-            (config().get('honeypot', 'data_path'),)
+        userdb_file = '%s/userdb.txt' % (config().get('honeypot', 'data_path'))
 
         # Note: this is subject to races between kippo instances, but hey ...
         f = open(userdb_file, 'w')
@@ -68,14 +67,15 @@ class UserDB(object):
             f.write('%s:%d:%s\n' % (login, uid, passwd))
         f.close()
 
-    def checklogin(self, thelogin, thepasswd):
+    def checklogin(self, thelogin, thepasswd, src_ip):
         '''check entered username/password against database'''
         '''note that it allows multiple passwords for a single username'''
         '''it also knows wildcard '*' for any password'''
         '''prepend password with ! to explicitly deny it. Denials must come before wildcards'''
+        '''src_ip contains the client source IP address'''
         for (login, uid, passwd) in self.userdb:
             # explicitly fail on !password
-            if login == thelogin and passwd == '!'+thepasswd:
+            if login == thelogin and passwd == '!' + thepasswd:
                 return False
             if login == thelogin and passwd in (thepasswd, '*'):
                 return True
@@ -101,7 +101,6 @@ class UserDB(object):
 
     def allocUID(self):
         '''allocate the next UID'''
-
         min_uid = 0
         for (login, uid, passwd) in self.userdb:
             if uid > min_uid:
@@ -116,20 +115,41 @@ class UserDB(object):
 
 @implementer(ICredentialsChecker)
 class HoneypotPublicKeyChecker:
+
     """
     Checker that accepts, logs and denies public key authentication attempts
     """
 
-    credentialInterfaces = (ISSHPrivateKey,)
+    credentialInterfaces = (ISSHPrivateKey, )
 
     def requestAvatarId(self, credentials):
         _pubKey = keys.Key.fromString(credentials.blob)
         log.msg(format='public key attempt for user %(username)s with fingerprint %(fingerprint)s',
-            username=credentials.username, fingerprint=_pubKey.fingerprint())
-        return failure.Failure(error.ConchError("Incorrect signature"))
+                username=credentials.username,
+                fingerprint=_pubKey.fingerprint())
+        return failure.Failure(error.ConchError('Incorrect signature'))
+
+# This credential interface also provides an IP address
+@implementer(IUsernamePassword)
+class UsernamePasswordIP:
+
+    def __init__(self, username, password, ip):
+        self.username = username
+        self.password = password
+        self.ip = ip
+
+# This credential interface also provides an IP address
+@implementer(IPluggableAuthenticationModules)
+class PluggableAuthenticationModulesIP:
+
+    def __init__(self, username, pamConversion, ip):
+        self.username = username
+        self.pamConversion = pamConversion
+        self.ip = ip
 
 @implementer(ICredentialsChecker)
 class HoneypotPasswordChecker:
+
     """
     Checker that accepts "keyboard-interactive" and "password"
     """
@@ -138,37 +158,38 @@ class HoneypotPasswordChecker:
 
     def requestAvatarId(self, credentials):
         if hasattr(credentials, 'password'):
-            if self.checkUserPass(credentials.username, credentials.password):
+            if self.checkUserPass(credentials.username, credentials.password,
+                                  credentials.ip):
                 return defer.succeed(credentials.username)
             else:
                 return defer.fail(UnauthorizedLogin())
         elif hasattr(credentials, 'pamConversion'):
             return self.checkPamUser(credentials.username,
-                credentials.pamConversion)
+                                     credentials.pamConversion, credentials.ip)
         return defer.fail(UnhandledCredentials())
 
-    def checkPamUser(self, username, pamConversion):
-        r = pamConversion((('Password:', 1),))
-        return r.addCallback(self.cbCheckPamUser, username)
+    def checkPamUser(self, username, pamConversion, ip):
+        r = pamConversion((('Password:', 1), ))
+        return r.addCallback(self.cbCheckPamUser, username, ip)
 
-    def cbCheckPamUser(self, responses, username):
-        for response, zero in responses:
-            if self.checkUserPass(username, response):
+    def cbCheckPamUser(self, responses, username, ip):
+        for (response, zero) in responses:
+            if self.checkUserPass(username, response, ip):
                 return defer.succeed(username)
         return defer.fail(UnauthorizedLogin())
 
-    def checkUserPass(self, theusername, thepassword):
-        if UserDB().checklogin(theusername, thepassword):
-            #log.msg( 'login attempt [%s/%s] succeeded' % (theusername, thepassword) )
-            log.msg( eventid='KIPP0002',
-                format='login attempt [%(username)s/%(password)s] succeeded',
-                username=theusername, password=thepassword )
+    def checkUserPass(self, theusername, thepassword, ip):
+        if UserDB().checklogin(theusername, thepassword, ip):
+            # log.msg( 'login attempt [%s/%s] succeeded' % (theusername, thepassword) )
+            log.msg(eventid='KIPP0002',
+                    format='login attempt [%(username)s/%(password)s] succeeded',
+                    username=theusername, password=thepassword)
             return True
         else:
-            #log.msg( 'login attempt [%s/%s] failed' % (theusername, thepassword) )
-            log.msg( eventid='KIPP0003',
-                format='login attempt [%(username)s/%(password)s] failed',
-                username=theusername, password=thepassword )
+            # log.msg( 'login attempt [%s/%s] failed' % (theusername, thepassword) )
+            log.msg(eventid='KIPP0003',
+                    format='login attempt [%(username)s/%(password)s] failed',
+                    username=theusername, password=thepassword)
             return False
 
 # vim: set sw=4 et:

--- a/kippo/core/ssh.py
+++ b/kippo/core/ssh.py
@@ -55,6 +55,23 @@ class HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer):
     def ssh_USERAUTH_REQUEST(self, packet):
         self.sendBanner()
         return userauth.SSHUserAuthServer.ssh_USERAUTH_REQUEST(self, packet)
+        
+    # Overridden to pass src_ip to auth.UsernamePasswordIP
+    def auth_password(self, packet):
+        password = getNS(packet[1:])[0]
+        c = auth.UsernamePasswordIP(self.user, password, self.transport.src_ip)
+        return self.portal.login(c, None, conchinterfaces.IConchUser).addErrback(
+                                                        self._ebPassword)
+                                                        
+    # Overridden to pass src_ip to auth.PlubbableAuthenticationModulesIP
+    def auth_keyboard_interactive(self, packet):
+        if self._pamDeferred is not None:
+            self.transport.sendDisconnect(
+                    transport.DISCONNECT_PROTOCOL_ERROR,
+                    "only one keyboard interactive attempt at a time")
+            return defer.fail(error.IgnoreAuthentication())
+        c = auth.PluggableAuthenticationModulesIP(self.user, self._pamConv, self.transport.src_ip)
+        return self.portal.login(c, None, conchinterfaces.IConchUser)
 
 # As implemented by Kojoney
 class HoneyPotSSHFactory(factory.SSHFactory):
@@ -185,6 +202,8 @@ class HoneyPotTransport(sshserver.KippoSSHServerTransport):
     def connectionMade(self):
         self.transportId = uuid.uuid4().hex[:8]
         self.interactors = []
+        # store src_ip to use in HoneyPotSSHUserAuthServer
+        self.src_ip=self.transport.getPeer().host
 
         log.msg( eventid='KIPP0001',
            format='New connection: %(src_ip)s:%(src_port)s (%(dst_ip)s:%(dst_port)s) [session: %(sessionno)s]',


### PR DESCRIPTION
I added 2 implementation classes for 2 new credentialInterfaces:
UsernamePasswordIP and PluggableAuthenticationModulesIP.
Then in the HoneyPotSSHUserAuthServer(userauth.SSHUserAuthServer) class
in ssh.py I added (and overrode) the 2 methods: def auth_password(self,
packet) and def auth_keyboard_interactive(self, packet).

In the overridden methods I pass the client src IP address to the 2 new
credentialInterfaces.
By doing so we have the src IP address available in the requestAvatarId
method in HoneypotPasswordchecker and this can be passed to other
methods like checkUserPassword and checklogin.